### PR TITLE
Fix compatibility for Django 1.10

### DIFF
--- a/django_docker/django_docker/urls.py
+++ b/django_docker/django_docker/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, include, url
-
+from django.conf.urls import include, url
+from hello_world.views import hello_world
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^$', 'hello_world.views.hello_world', name='hello_world'),
-)
+    url(r'^$', hello_world, name='hello_world'),
+]


### PR DESCRIPTION
Fixes Issue #19 

Django Docs reference:
https://docs.djangoproject.com/en/1.10/ref/urls/

Example:
https://stackoverflow.com/questions/38744285/django-urls-error-view-must-be-a-callable-or-a-list-tuple-in-the-case-of-includ
