### PR TITLE
Add pyopenssl to avoid InsecurePlatformWarning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN easy_install pip
 
 # Handle urllib3 InsecurePlatformWarning
 RUN apt-get install -y libffi-dev libssl-dev libpython2.7-dev
-RUN pip install requests[security] ndg-httpsclient pyasn1
+RUN pip install requests[security] pyopenssl ndg-httpsclient pyasn1
 
 # Configure Django project
 ADD . /code


### PR DESCRIPTION
Build seems to fail without.