### PR TITLE
Allow MySQL to access 3306 port on Host

### DIFF
--- a/django_docker/django_docker/settings_production.py
+++ b/django_docker/django_docker/settings_production.py
@@ -15,7 +15,7 @@ DATABASES = {
         'USER': os.environ['DATABASE_USERNAME'],
         'PASSWORD': os.environ['DATABASE_PASSWORD'], # Entered via fab command; leave blank if using SQLite
         'HOST': os.environ['DATABASE_HOST'],                      # Empty for localhost through domain sockets or '127.0.0.1' for localhost through TCP.
-        'PORT': '',                      # Set to empty string for default.
+        'PORT': '6033',                      # Set to empty string for default.
     }
 }
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -32,6 +32,7 @@ def deploy_production():
     -d \
     -p 80:80 \
     -p 443:443 \
+    -p 6033:3306 \
     --env DJANGO_PRODUCTION=true \
     --env ROOT_PASSWORD={ROOT_PASSWORD} \
     --env DATABASE_HOST={DATABASE_HOST} \


### PR DESCRIPTION
Fixes this error:

> out: docker: Error response from daemon: driver failed programming external connectivity on endpoint relaxed_booth: Error starting userland proxy: listen tcp 0.0.0.0:3306: bind: address already in use.
